### PR TITLE
feat: localize bot responses to Armenian

### DIFF
--- a/src/buttons/close.ts
+++ b/src/buttons/close.ts
@@ -32,7 +32,7 @@ export default class CloseButton extends NeedleButton {
 	public getBuilder(): ButtonBuilder {
 		return new ButtonBuilder()
 			.setCustomId(this.customId)
-			.setLabel("Archive thread")
+			.setLabel("Արխիվացնել թրեդը")
 			.setStyle(ButtonStyle.Success)
 			.setEmoji("1010182198923636797"); // :archive_3_0:
 	}

--- a/src/buttons/title.ts
+++ b/src/buttons/title.ts
@@ -32,7 +32,7 @@ export default class TitleButton extends NeedleButton {
 	public getBuilder(): ButtonBuilder {
 		return new ButtonBuilder()
 			.setCustomId(this.customId)
-			.setLabel("Edit title")
+			.setLabel("Խմբագրել վերնագիրը")
 			.setStyle(ButtonStyle.Primary)
 			.setEmoji("1010182200018350111"); // :title_3_0:
 	}

--- a/src/commands/auto-thread.ts
+++ b/src/commands/auto-thread.ts
@@ -36,13 +36,13 @@ import type { ModalTextInput } from "../models/ModalTextInput.js";
 
 export default class AutoThreadCommand extends NeedleCommand {
 	public readonly name = "auto-thread";
-	public readonly description = "Configure automatic creation of threads in a channel";
+	public readonly description = "Կարգավորել թրեդերի ավտոմատ ստեղծումը ալիքում";
 	public readonly category = CommandCategory.Configuration;
 	protected readonly defaultPermissions = PermissionFlagsBits.ManageThreads;
 
 	public async hasPermissionToExecuteHere(
 		member: Nullish<GuildMember>,
-		channel: Nullish<GuildTextBasedChannel>
+		channel: Nullish<GuildTextBasedChannel>,
 	): Promise<boolean> {
 		if (channel?.isThread()) return false;
 		if (channel?.isVoiceBased()) return false;
@@ -63,19 +63,23 @@ export default class AutoThreadCommand extends NeedleCommand {
 		const botPermissions = botMember?.permissionsIn(targetChannel);
 
 		if (!botPermissions?.has(PermissionFlagsBits.ViewChannel)) {
-			return replyInSecret("Needle does not have permission to see this channel");
+			return replyInSecret("Needle-ը չունի այս ալիքը տեսնելու թույլտվություն");
 		}
 
 		if (!botPermissions.has(PermissionFlagsBits.CreatePublicThreads)) {
-			return replyInSecret("Needle does not have permission to create threads in this channel");
+			return replyInSecret("Needle-ը չունի այս ալիքում թրեդեր ստեղծելու թույլտվություն");
 		}
 
 		if ((options.getInteger("slowmode") ?? 0) > 0 && !botPermissions?.has(PermissionFlagsBits.ManageThreads)) {
-			return replyInSecret('Needle needs the "Manage Threads" permission to set a slowmode in the thread');
+			return replyInSecret(
+				'Needle-ին անհրաժեշտ է "Manage Threads" թույլտվությունը թրեդում դանդաղ ռեժիմ սահմանելու համար',
+			);
 		}
 
 		if (options.getInteger("status-reactions") && !botPermissions?.has(PermissionFlagsBits.AddReactions)) {
-			return replyInSecret('Needle needs the "Add Reactions" permission to add reactions to messages');
+			return replyInSecret(
+				'Needle-ին անհրաժեշտ է "Add Reactions" թույլտվությունը հաղորդագրություններին ռեակցիաներ ավելացնելու համար',
+			);
 		}
 
 		const guildConfig = this.bot.configs.get(guildId);
@@ -87,7 +91,7 @@ export default class AutoThreadCommand extends NeedleCommand {
 		const openReplyMessageModal = replyType === ReplyMessageOption.Custom;
 
 		if (targetChannel?.isThread() || targetChannel?.isVoiceBased()) {
-			return replyInSecret("Can not create threads in this type of channel.");
+			return replyInSecret("Այս տեսակի ալիքում հնարավոր չէ ստեղծել թրեդեր։");
 		}
 
 		if (options.getInteger("toggle") === ToggleOption.Off) {
@@ -97,11 +101,11 @@ export default class AutoThreadCommand extends NeedleCommand {
 
 			guildConfig.threadChannels.splice(oldConfigIndex, 1);
 			this.bot.configs.set(guildId, guildConfig);
-			return replyInPublic(`Removed auto-threading in <#${channelId}>`);
+			return replyInPublic(`Ավտո-թրեդը հանվեց <#${channelId}> ալիքում`);
 		}
 
 		if (+openTitleModal + +openReplyMessageModal + +openReplyButtonsModal > 1) {
-			return replyInSecret('Please set one option to "Custom" at a time.');
+			return replyInSecret("Խնդրում ենք միաժամանակ միայն մեկ ընտրանք սահմանել «Custom»։");
 		}
 
 		let newCustomTitle;
@@ -119,26 +123,26 @@ export default class AutoThreadCommand extends NeedleCommand {
 					{ customId: "maxTitleLength", value: oldMaxLength.toString() },
 					{ customId: "regexJoinText", value: oldJoinText },
 				],
-				context
+				context,
 			);
 
 			newMaxTitleLength = Number.parseInt(newMaxLengthString);
 			if (Number.isNaN(newMaxTitleLength) || newMaxTitleLength < 1 || newMaxTitleLength > 100) {
-				return replyInSecret(newMaxLengthString + " is not a number between 1-100.");
+				return replyInSecret(newMaxLengthString + " թիվ չէ 1-100 միջակայքում։");
 			}
 
 			const hasMoreThanTwoSlashes = newCustomTitle.split("/").length - 1 > 2;
 			if (hasMoreThanTwoSlashes) {
-				return replyInSecret("Custom titles can not have more than one regex.");
+				return replyInSecret("Սեփական վերնագրերը չեն կարող ունենալ մեկից ավելի regex։");
 			}
 
 			const { inputWithRegexVariable, regex } = extractRegex(newCustomTitle);
 			if (regex && !safe_regex(regex)) {
-				return replyInSecret("Unsafe regex detected, please try again with a safe regex.");
+				return replyInSecret("Անվտանգ չէ regex-ը, խնդրում ենք փորձել անվտանգ regex-ով։");
 			}
 
 			if (removeInvalidThreadNameChars(inputWithRegexVariable).length === 0) {
-				return replyInSecret("Invalid title, please provide at least one valid character.");
+				return replyInSecret("Անվավեր վերնագիր, խնդրում ենք ապահովել գոնե մեկ վավեր նշան։");
 			}
 		}
 
@@ -156,7 +160,7 @@ export default class AutoThreadCommand extends NeedleCommand {
 			[newReplyMessage] = await this.getTextInputsFromModal(
 				"custom-reply-message",
 				[{ customId: "message", value: oldValue }],
-				context
+				context,
 			);
 		}
 
@@ -170,9 +174,9 @@ export default class AutoThreadCommand extends NeedleCommand {
 		let newTitleButtonStyle;
 		if (openReplyButtonsModal) {
 			// TODO: This default is defined in like 3 places, need to have a default config somewhere probably..
-			const oldCloseText = oldAutoThreadConfig?.closeButtonText ?? "Archive thread";
+			const oldCloseText = oldAutoThreadConfig?.closeButtonText ?? "Արխիվացնել թրեդը";
 			const oldCloseStyle = oldAutoThreadConfig?.closeButtonStyle ?? "green";
-			const oldTitleText = oldAutoThreadConfig?.titleButtonText ?? "Edit title";
+			const oldTitleText = oldAutoThreadConfig?.titleButtonText ?? "Խմբագրել վերնագիրը";
 			const oldTitleStyle = oldAutoThreadConfig?.titleButtonStyle ?? "blurple";
 
 			[newCloseButtonText, newCloseButtonStyle, newTitleButtonText, newTitleButtonStyle] =
@@ -184,18 +188,18 @@ export default class AutoThreadCommand extends NeedleCommand {
 						{ customId: "titleText", value: oldTitleText },
 						{ customId: "titleStyle", value: oldTitleStyle },
 					],
-					context
+					context,
 				);
 
 			if (!this.isValidButtonStyle(newCloseButtonStyle) || !this.isValidButtonStyle(newTitleButtonStyle)) {
-				return replyInSecret("Invalid button style. Allowed values: blurple/grey/green/red.");
+				return replyInSecret("Կոճակի սխալ ոճ։ Թույլատրելի արժեքներ՝ blurple/grey/green/red։");
 			}
 		}
 
 		if (options.getInteger("reply-buttons") === ReplyButtonsOption.Default) {
-			newCloseButtonText = "Archive thread";
+			newCloseButtonText = "Արխիվացնել թրեդը";
 			newCloseButtonStyle = "green";
-			newTitleButtonText = "Edit title";
+			newTitleButtonText = "Խմբագրել վերնագիրը";
 			newTitleButtonStyle = "blurple";
 		}
 
@@ -216,7 +220,7 @@ export default class AutoThreadCommand extends NeedleCommand {
 			newCloseButtonText,
 			newCloseButtonStyle,
 			newTitleButtonText,
-			newTitleButtonStyle
+			newTitleButtonStyle,
 		);
 
 		if (JSON.stringify(oldAutoThreadConfig) === JSON.stringify(newAutoThreadConfig)) {
@@ -225,10 +229,10 @@ export default class AutoThreadCommand extends NeedleCommand {
 
 		let interactionReplyMessage;
 		if (oldConfigIndex > -1) {
-			interactionReplyMessage = `Updated settings for auto-threading in <#${channelId}>`;
+			interactionReplyMessage = `Ավտո-թրեդի կարգավորումները թարմացվեցին <#${channelId}> ալիքում`;
 			guildConfig.threadChannels[oldConfigIndex] = newAutoThreadConfig;
 		} else {
-			interactionReplyMessage = `Enabled auto-threading in <#${channelId}>`;
+			interactionReplyMessage = `Ավտո-թրեդը միացվեց <#${channelId}> ալիքում`;
 			guildConfig.threadChannels.push(newAutoThreadConfig);
 		}
 
@@ -239,7 +243,7 @@ export default class AutoThreadCommand extends NeedleCommand {
 	private async getTextInputsFromModal<T extends ModalTextInput[]>(
 		modalName: string,
 		inputs: T,
-		context: InteractionContext
+		context: InteractionContext,
 	): Promise<SameLengthTuple<T, string>> {
 		if (!context.isModalOpenable()) return inputs.map(() => "") as SameLengthTuple<T, string>;
 
@@ -267,106 +271,106 @@ export default class AutoThreadCommand extends NeedleCommand {
 			.addChannelOption(option =>
 				option
 					.setName("channel")
-					.setDescription("Which channel? Current channel by default.")
-					.addChannelTypes(ChannelType.GuildText, ChannelType.GuildNews)
+					.setDescription("Որ ալիքը? Լռելյայն՝ ընթացիկ ալիքը։")
+					.addChannelTypes(ChannelType.GuildText, ChannelType.GuildNews),
 			)
 			.addIntegerOption(option =>
 				option
 					.setName("toggle")
-					.setDescription("Should auto-threading be turned on or off?")
+					.setDescription("Ավտո-թրեդը միացվա՞ծ լինի, թե՞ անջատված։")
 					.addChoices(
-						{ name: "Auto-threading ON (ᴅᴇꜰᴀᴜʟᴛ)", value: ToggleOption.On },
-						{ name: "Auto-threading OFF", value: ToggleOption.Off }
-					)
+						{ name: "Ավտո-թրեդը միացված (լռելյայն)", value: ToggleOption.On },
+						{ name: "Ավտո-թրեդը անջատված", value: ToggleOption.Off },
+					),
 			)
 			.addIntegerOption(option =>
 				option
 					.setName("title-format")
-					.setDescription("How should the thread title look? 🔥")
+					.setDescription("Ինչպե՞ս լինի թրեդի վերնագիրը։ 🔥")
 					.addChoices(
-						{ name: "First 50 characters of message (ᴅᴇꜰᴀᴜʟᴛ)", value: TitleType.FirstFiftyChars },
-						{ name: "Nickname (yyyy-MM-dd) 🔥", value: TitleType.NicknameDate },
-						{ name: "First line of message", value: TitleType.FirstLineOfMessage },
-						{ name: "Custom 🔥", value: TitleType.Custom }
-					)
-			)
-			.addIntegerOption(option =>
-				option.setName("reply-message").setDescription("How should Needle reply in the thread? 🔥").addChoices(
-					{
-						name: 'Use "SuccessThreadCreate" setting (ᴅᴇꜰᴀᴜʟᴛ)',
-						value: ReplyMessageOption.Default,
-					},
-					{ name: "Custom message 🔥", value: ReplyMessageOption.Custom }
-				)
+						{ name: "Հաղորդագրության առաջին 50 նիշերը (լռելյայն)", value: TitleType.FirstFiftyChars },
+						{ name: "Մականուն (yyyy-MM-dd) 🔥", value: TitleType.NicknameDate },
+						{ name: "Հաղորդագրության առաջին տողը", value: TitleType.FirstLineOfMessage },
+						{ name: "Սեփական 🔥", value: TitleType.Custom },
+					),
 			)
 			.addIntegerOption(option =>
 				option
-					.setName("reply-buttons")
-					.setDescription("What should the buttons of the reply look like?")
+					.setName("reply-message")
+					.setDescription("Ինչպե՞ս պետք է Needle-ը պատասխան տա թրեդում? 🔥")
 					.addChoices(
 						{
-							name: "Green archive button, Blurple edit button (ᴅᴇꜰᴀᴜʟᴛ)",
-							value: ReplyButtonsOption.Default,
+							name: 'Օգտագործել "SuccessThreadCreate" կարգավորումը (լռելյայն)',
+							value: ReplyMessageOption.Default,
 						},
-						{ name: "Custom 🔥", value: ReplyButtonsOption.Custom }
-					)
+						{ name: "Սեփական հաղորդագրություն 🔥", value: ReplyMessageOption.Custom },
+					),
+			)
+			.addIntegerOption(option =>
+				option.setName("reply-buttons").setDescription("Ինչ տեսք ունենան պատասխանի կոճակները?").addChoices(
+					{
+						name: "Կանաչ արխիվացման կոճակ, blurple խմբագրման կոճակ (լռելյայն)",
+						value: ReplyButtonsOption.Default,
+					},
+					{ name: "Սեփական 🔥", value: ReplyButtonsOption.Custom },
+				),
 			)
 			.addIntegerOption(option =>
 				option
 					.setName("include-bots")
-					.setDescription("Should threads be created on bot messages?")
+					.setDescription("Թրեդերը ստեղծվեն բոտերի հաղորդագրությունների՞ համար")
 					.addChoices(
-						{ name: "Exclude bots (ᴅᴇꜰᴀᴜʟᴛ)", value: ToggleOption.Off },
-						{ name: "Include bots", value: ToggleOption.On }
-					)
+						{ name: "Բացառել բոտերը (լռելյայն)", value: ToggleOption.Off },
+						{ name: "Ներառել բոտերը", value: ToggleOption.On },
+					),
 			)
 			.addIntegerOption(option =>
 				option
 					.setName("delete-behavior")
-					.setDescription("What should happen to the thread if the start message is deleted?")
+					.setDescription("Ի՞նչ անել թրեդը, եթե մեկնարկային հաղորդագրությունը ջնջվի?")
 					.addChoices(
 						{
-							name: "Delete if thread is empty, otherwise archive (ᴅᴇꜰᴀᴜʟᴛ)",
+							name: "Ջնջել, եթե թրեդը դատարկ է, այլապես արխիվացնել (լռելյայն)",
 							value: DeleteBehavior.DeleteIfEmptyElseArchive,
 						},
-						{ name: "Always archive", value: DeleteBehavior.Archive },
-						{ name: "Always delete ❗", value: DeleteBehavior.Delete },
-						{ name: "Do nothing", value: DeleteBehavior.Nothing }
-					)
+						{ name: "Միշտ արխիվացնել", value: DeleteBehavior.Archive },
+						{ name: "Միշտ ջնջել ❗", value: DeleteBehavior.Delete },
+						{ name: "Ոչինչ չանել", value: DeleteBehavior.Nothing },
+					),
 			)
 			.addIntegerOption(option =>
 				option
 					.setName("archive-behavior")
-					.setDescription("What should happen when users close a thread?")
+					.setDescription("Ինչ պետք է տեղի ունենա, երբ օգտատերերը փակեն թրեդը?")
 					.addChoices(
-						{ name: "Archive immediately (ᴅᴇꜰᴀᴜʟᴛ)", value: ToggleOption.On },
-						{ name: "Hide after 1 hour of inactivity", value: ToggleOption.Off }
-					)
+						{ name: "Արխիվացնել անմիջապես (լռելյայն)", value: ToggleOption.On },
+						{ name: "Թաքցնել 1 ժամ անգործությունից հետո", value: ToggleOption.Off },
+					),
 			)
 			.addIntegerOption(option =>
 				option
 					.setName("status-reactions")
-					.setDescription("Should thread statuses be shown with emoji reactions?")
+					.setDescription("Թրեդի կարգավիճակներն արտացոլե՞ն ռեակցիաներով")
 					.addChoices(
-						{ name: "Reactions OFF (ᴅᴇꜰᴀᴜʟᴛ)", value: ToggleOption.Off },
-						{ name: "Reactions ON", value: ToggleOption.On }
-					)
+						{ name: "Ռեակցիաները անջատված (լռելյայն)", value: ToggleOption.Off },
+						{ name: "Ռեակցիաները միացված", value: ToggleOption.On },
+					),
 			)
 			.addIntegerOption(option =>
 				option
 					.setName("slowmode")
-					.setDescription("How long should the slowmode be in created threads?")
+					.setDescription("Որքա՞ն լինի դանդաղ ռեժիմը ստեղծված թրեդերում?")
 					.addChoices(
-						{ name: "Off (ᴅᴇꜰᴀᴜʟᴛ)", value: 0 },
-						{ name: "1 second", value: 1 },
-						{ name: "5 seconds", value: 5 },
-						{ name: "30 seconds", value: 30 },
-						{ name: "1 minute", value: 60 },
-						{ name: "5 minutes", value: 300 },
-						{ name: "15 minutes", value: 900 },
-						{ name: "1 hour", value: 3600 },
-						{ name: "6 hours", value: 21600 }
-					)
+						{ name: "Անջատված (լռելյայն)", value: 0 },
+						{ name: "1 վայրկյան", value: 1 },
+						{ name: "5 վայրկյան", value: 5 },
+						{ name: "30 վայրկյան", value: 30 },
+						{ name: "1 րոպե", value: 60 },
+						{ name: "5 րոպե", value: 300 },
+						{ name: "15 րոպե", value: 900 },
+						{ name: "1 ժամ", value: 3600 },
+						{ name: "6 ժամ", value: 21600 },
+					),
 			);
 	}
 }

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -21,7 +21,7 @@ import NeedleCommand from "../models/NeedleCommand.js";
 
 export default class CloseCommand extends NeedleCommand {
 	public readonly name = "close";
-	public readonly description = "Close a thread";
+	public readonly description = "Փակել թրեդը";
 	public readonly category = CommandCategory.ThreadOnly;
 
 	public async hasPermissionToExecuteHere(member: GuildMember, channel: GuildTextBasedChannel): Promise<boolean> {

--- a/src/commands/factory-reset.ts
+++ b/src/commands/factory-reset.ts
@@ -20,7 +20,7 @@ import NeedleCommand from "../models/NeedleCommand.js";
 
 export default class FactoryResetCommand extends NeedleCommand {
 	public readonly name = "factory-reset";
-	public readonly description = "Reset Needle to factory settings";
+	public readonly description = "Վերականգնել Needle-ը գործարանային կարգավորումներով";
 	public readonly category = CommandCategory.Configuration;
 	protected readonly defaultPermissions = PermissionFlagsBits.ManageThreads;
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -21,7 +21,7 @@ import NeedleCommand from "../models/NeedleCommand.js";
 
 export default class HelpCommand extends NeedleCommand {
 	public readonly name = "help";
-	public readonly description = "See Needle's commands";
+	public readonly description = "Դիտել Needle-ի հրամանները";
 	public readonly category = CommandCategory.Info;
 
 	private readonly EMBED_COLOR = "#2f3136";
@@ -31,11 +31,11 @@ export default class HelpCommand extends NeedleCommand {
 		return builder.addStringOption(option =>
 			option
 				.setName("filter")
-				.setDescription("Which commands do you want to see?")
+				.setDescription("Որ հրամաններն եք ցանկանում տեսնել?")
 				.addChoices(
-					{ name: "Available to you in current channel (ᴅᴇꜰᴀᴜʟᴛ)", value: "default" },
-					{ name: "All Needle commands", value: "all" }
-				)
+					{ name: "Այստեղ հասանելի հրամաններ (լռելյայն)", value: "default" },
+					{ name: "Needle-ի բոլոր հրամանները", value: "all" },
+				),
 		);
 	}
 
@@ -48,7 +48,7 @@ export default class HelpCommand extends NeedleCommand {
 		const commandsEmbed = await this.getCommandsEmbed(member, channel, showAll);
 
 		await context.interaction.reply({
-			content: `Need more help with Needle? Join us in the [support server](${this.SUPPORT_SERVER_URL})!`,
+			content: `Ավելի շատ օգնությո՞ւն է պետք Needle-ի հետ։ Միացեք [աջակցության սերվերին](${this.SUPPORT_SERVER_URL})։`,
 			embeds: [commandsEmbed],
 			ephemeral: true,
 		});
@@ -57,7 +57,7 @@ export default class HelpCommand extends NeedleCommand {
 	private async getCommandsEmbed(
 		member: Nullish<GuildMember>,
 		channel: Nullish<GuildTextBasedChannel>,
-		showAll: boolean
+		showAll: boolean,
 	): Promise<EmbedBuilder> {
 		const commands = await this.bot.getAllCommands();
 
@@ -79,13 +79,13 @@ export default class HelpCommand extends NeedleCommand {
 		if (fields.length === 0) {
 			return new EmbedBuilder()
 				.setColor(this.EMBED_COLOR)
-				.setDescription("You do not have permission to use any Needle commands here.");
+				.setDescription("Դուք այստեղ չունեք Needle-ի որևէ հրաման օգտագործելու թույլտվություն։");
 		}
 
 		const builder = new EmbedBuilder().setColor(this.EMBED_COLOR).setFields(fields);
 		if (!seeingAllCommands) {
 			builder.setFooter({
-				text: 'Only showing commands available to you in this channel.\nUse "/help filter: all" to see all commands 👈',
+				text: 'Ցույց ենք տալիս միայն այս ալիքում ձեզ հասանելի հրամանները։\nՕգտագործեք "/help filter: all"՝ բոլոր հրամանները տեսնելու համար 👈',
 			});
 		}
 
@@ -96,7 +96,7 @@ export default class HelpCommand extends NeedleCommand {
 		commands: NeedleCommand[],
 		member: Nullish<GuildMember>,
 		channel: Nullish<GuildTextBasedChannel>,
-		showAll: boolean
+		showAll: boolean,
 	): Promise<string[]> {
 		const output = [];
 		for (const command of commands) {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -24,7 +24,7 @@ import { EmbedBuilder } from "discord.js";
 
 export default class InfoCommand extends NeedleCommand {
 	public readonly name = "info";
-	public readonly description = "See information about Needle";
+	public readonly description = "Տեսնել տեղեկություններ Needle-ի մասին";
 	public readonly category = CommandCategory.Info;
 
 	private readonly infoService: InformationService;
@@ -53,29 +53,29 @@ export default class InfoCommand extends NeedleCommand {
 		const version = process.env.npm_package_version;
 
 		let fields = [
-			{ name: "Servers", value: codeBlock(serverCount), inline: true },
-			{ name: "Users", value: codeBlock(userCount), inline: true },
-			{ name: "Largest server", value: codeBlock(largestServer), inline: true },
-			{ name: "Ping", value: codeBlock(ping), inline: true },
-			{ name: "Uptime", value: codeBlock(uptime), inline: true },
+			{ name: "Սերվերներ", value: codeBlock(serverCount), inline: true },
+			{ name: "Օգտագործողներ", value: codeBlock(userCount), inline: true },
+			{ name: "Մեծագույն սերվեր", value: codeBlock(largestServer), inline: true },
+			{ name: "Պինգ", value: codeBlock(ping), inline: true },
+			{ name: "Աշխատանքային ժամանակ", value: codeBlock(uptime), inline: true },
 		];
 
 		if (version) {
-			fields.push({ name: "Version", value: codeBlock(version), inline: true });
+			fields.push({ name: "Տարբերակ", value: codeBlock(version), inline: true });
 		}
 
 		if (isOwner) {
 			fields = fields.concat([
-				{ name: "CPU usage", value: codeBlock(cpuPercent + "%"), inline: true },
-				{ name: "RAM usage", value: codeBlock(ramPercent + "%"), inline: true },
-				{ name: "Free RAM", value: codeBlock(freeRamMb + " MB"), inline: true },
+				{ name: "Մշակիչի օգտագործում", value: codeBlock(cpuPercent + "%"), inline: true },
+				{ name: "RAM-ի օգտագործում", value: codeBlock(ramPercent + "%"), inline: true },
+				{ name: "Ազատ RAM", value: codeBlock(freeRamMb + " MB"), inline: true },
 			]);
 		}
 
 		return new EmbedBuilder()
 			.setColor("#2f3136")
 			.setDescription(
-				"Needle is a bot that creates [threads](https://discord.com/blog/connect-the-conversation-with-threads-on-discord) in certain channels automatically. You can interact with Needle through [slash commands](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ) and buttons. If you want help with using this bot, feel free to join the [support server](https://discord.gg/8BmnndXHp6).\n\n🧑‍💼 **` STATS `**"
+				"Needle-ը բոտ է, որը որոշ ալիքներում ավտոմատ ստեղծում է [թրեդեր](https://discord.com/blog/connect-the-conversation-with-threads-on-discord): Needle-ի հետ կարող եք աշխատել [slash հրամաններով](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ) և կոճակներով։ Եթե ցանկանում եք օգնություն բոտի օգտագործման հարցում, միացեք [աջակցության սերվերին](https://discord.gg/8BmnndXHp6)।\n\n🧑‍💼 **` Վիճակագրություն `**",
 			)
 			.setFields(fields);
 	}

--- a/src/commands/setting.ts
+++ b/src/commands/setting.ts
@@ -22,7 +22,7 @@ import NeedleCommand from "../models/NeedleCommand.js";
 
 export default class SettingCommand extends NeedleCommand {
 	public readonly name = "setting";
-	public readonly description = "View or change Needle settings for this server";
+	public readonly description = "Դիտել կամ փոխել Needle-ի կարգավորումները այս սերվերի համար";
 	public readonly category = CommandCategory.Configuration;
 	protected readonly defaultPermissions = PermissionFlagsBits.ManageThreads;
 
@@ -35,9 +35,9 @@ export default class SettingCommand extends NeedleCommand {
 		return builder.addIntegerOption(option =>
 			option
 				.setName("setting-name")
-				.setDescription("The name of the setting")
+				.setDescription("Կարգավորման անունը")
 				.setRequired(true)
-				.setChoices(...choices)
+				.setChoices(...choices),
 		);
 	}
 
@@ -54,7 +54,7 @@ export default class SettingCommand extends NeedleCommand {
 		const submitInteraction = await modal.openAndAwaitSubmit(
 			context.interaction,
 			[{ customId: "setting", value: oldValue }],
-			settingName
+			settingName,
 		);
 
 		context.setInteractionToReplyTo(submitInteraction);
@@ -65,12 +65,12 @@ export default class SettingCommand extends NeedleCommand {
 		}
 
 		if (newValue.trim().length === 0) {
-			return context.replyInSecret("Setting must be at least 1 non-whitespace character.");
+			return context.replyInSecret("Կարգավորումը պետք է պարունակի առնվազն մեկ ոչ-դատարկ նիշ։");
 		}
 
 		autoThreadConfig.settings[settingName] = newValue;
 		this.bot.configs.set(guildId, autoThreadConfig);
 
-		await context.replyInSecret("Setting successfully changed.");
+		await context.replyInSecret("Կարգավորումը հաջողությամբ փոխվեց։");
 	}
 }

--- a/src/commands/title.ts
+++ b/src/commands/title.ts
@@ -22,17 +22,17 @@ import NeedleCommand from "../models/NeedleCommand.js";
 
 export default class TitleCommand extends NeedleCommand {
 	public readonly name = "title";
-	public readonly description = "Change the title of a thread";
+	public readonly description = "Փոխել թրեդի վերնագիրը";
 	public readonly category = CommandCategory.ThreadOnly;
 
 	public addOptions(builder: SlashCommandBuilder): SlashCommandBuilderWithOptions {
 		return builder.addStringOption(option =>
 			option
 				.setName("value")
-				.setDescription("The new title of the thread")
+				.setDescription("Թրեդի նոր վերնագիրը")
 				.setMinLength(1)
 				.setMaxLength(100)
-				.setRequired(true)
+				.setRequired(true),
 		);
 	}
 
@@ -77,6 +77,6 @@ export default class TitleCommand extends NeedleCommand {
 
 		await thread.setName(newThreadName);
 		this.bot.reportThreadRenamed(thread.id);
-		await replyInSecret("Success!");
+		await replyInSecret("Հաջողվեց։");
 	}
 }

--- a/src/modals/confirm-factory-reset.ts
+++ b/src/modals/confirm-factory-reset.ts
@@ -28,16 +28,16 @@ export default class ConfirmFactoryResetModal extends NeedleModal {
 	public get builder(): ModalBuilder {
 		const confirmInput = new TextInputBuilder()
 			.setCustomId("confirm")
-			.setLabel("Factory reset? (yes/no)")
-			.setValue("Yes")
-			.setPlaceholder("No")
+			.setLabel("Վերականգնել գործարանային կարգավորումները? (այո/ոչ)")
+			.setValue("Այո")
+			.setPlaceholder("Ոչ")
 			.setRequired(false)
 			.setStyle(TextInputStyle.Short);
 
 		const row = new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents([confirmInput]);
 		return new ModalBuilder()
 			.setCustomId(this.customId)
-			.setTitle("Reset Needle to factory settings")
+			.setTitle("Վերականգնել Needle-ը գործարանային կարգավորումներով")
 			.addComponents(row);
 	}
 
@@ -45,14 +45,14 @@ export default class ConfirmFactoryResetModal extends NeedleModal {
 		if (!context.isInGuild() || !context.isModalSubmit()) return;
 
 		const { replyInSecret, replyInPublic, interaction, settings } = context;
-		const isConfirmed = interaction.fields.getTextInputValue("confirm").toLowerCase() === "yes";
+		const isConfirmed = interaction.fields.getTextInputValue("confirm").toLowerCase() === "այո";
 		if (!isConfirmed) {
-			return replyInSecret("Action cancelled.");
+			return replyInSecret("Գործողությունը չեղարկվեց։");
 		}
 
 		const success = this.bot.configs.delete(interaction.guildId);
 		return success
-			? replyInPublic("Successfully reset Needle to factory settings.")
+			? replyInPublic("Needle-ը հաջողությամբ վերականգնվեց գործարանային կարգավորումներով։")
 			: replyInSecret(settings.ErrorNoEffect);
 	}
 }

--- a/src/modals/custom-reply-buttons.ts
+++ b/src/modals/custom-reply-buttons.ts
@@ -20,14 +20,14 @@ import NeedleModal from "../models/NeedleModal.js";
 export default class CustomReplyButtonsModal extends NeedleModal {
 	public customId = "custom-reply-buttons";
 	public get builder(): ModalBuilder {
-		const closeText = makeRow(this.getTextInput("Close"));
-		const closeStyle = makeRow(this.getStyleInput("Close", "Green"));
-		const titleText = makeRow(this.getTextInput("Title"));
-		const titleStyle = makeRow(this.getStyleInput("Title", "Blurple"));
+		const closeText = makeRow(this.getTextInput("Close", "Փակել"));
+		const closeStyle = makeRow(this.getStyleInput("Close", "Green", "Փակել"));
+		const titleText = makeRow(this.getTextInput("Title", "Վերնագիր"));
+		const titleStyle = makeRow(this.getStyleInput("Title", "Blurple", "Վերնագիր"));
 
 		return new ModalBuilder()
 			.setCustomId(this.customId)
-			.setTitle("Set custom buttons")
+			.setTitle("Սահմանել սեփական կոճակները")
 			.setComponents(closeText, closeStyle, titleText, titleStyle);
 	}
 
@@ -35,20 +35,20 @@ export default class CustomReplyButtonsModal extends NeedleModal {
 		// Not used, we only use openAndAwaitSubmit on this modal
 	}
 
-	private getTextInput(name: string): TextInputBuilder {
+	private getTextInput(name: string, label: string): TextInputBuilder {
 		return new TextInputBuilder()
 			.setCustomId(name.toLowerCase() + "Text")
-			.setLabel(name + " button text (empty = hidden)")
+			.setLabel(label + " կոճակի տեքստը (դատարկ = թաքնված)")
 			.setRequired(false)
-			.setPlaceholder("Hidden")
+			.setPlaceholder("Թաքնված")
 			.setStyle(TextInputStyle.Short)
 			.setMaxLength(80);
 	}
 
-	private getStyleInput(name: string, placeholder: string): TextInputBuilder {
+	private getStyleInput(name: string, placeholder: string, label: string): TextInputBuilder {
 		return new TextInputBuilder()
 			.setCustomId(name.toLowerCase() + "Style")
-			.setLabel(name + " button style (blurple/grey/green/red)")
+			.setLabel(label + " կոճակի ոճը (blurple/grey/green/red)")
 			.setRequired(true)
 			.setPlaceholder(placeholder.toUpperCase())
 			.setStyle(TextInputStyle.Short)

--- a/src/modals/custom-reply-message.ts
+++ b/src/modals/custom-reply-message.ts
@@ -27,13 +27,16 @@ export default class CustomReplyMessageModal extends NeedleModal {
 	public get builder(): ModalBuilder {
 		const messageInput = new TextInputBuilder()
 			.setCustomId("message")
-			.setLabel("Custom message (empty = hidden)")
+			.setLabel("Սեփական հաղորդագրություն (դատարկ = թաքնված)")
 			.setRequired(false)
-			.setPlaceholder("Hidden")
+			.setPlaceholder("Թաքնված")
 			.setStyle(TextInputStyle.Paragraph)
 			.setMaxLength(2000);
 		const row = new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(messageInput);
-		return new ModalBuilder().setCustomId(this.customId).setTitle("Set a custom reply message").addComponents(row);
+		return new ModalBuilder()
+			.setCustomId(this.customId)
+			.setTitle("Սահմանել սեփական պատասխան հաղորդագրություն")
+			.addComponents(row);
 	}
 
 	public async submit(): Promise<void> {

--- a/src/modals/custom-title-format.ts
+++ b/src/modals/custom-title-format.ts
@@ -22,26 +22,26 @@ export default class CustomTitleFormatModal extends NeedleModal {
 	public get builder(): ModalBuilder {
 		const titleInput = new TextInputBuilder()
 			.setCustomId("title")
-			.setLabel("Title format (RegEx supported)")
+			.setLabel("Վերնագրի ձևաչափը (կայքարեցված է RegEx)")
 			.setRequired(true)
-			.setPlaceholder("Help $USER_NICKNAME - /^[\\S\\s]/g")
+			.setPlaceholder("Օգնություն $USER_NICKNAME - /^[\\S\\s]/g")
 			.setStyle(TextInputStyle.Short);
 		const maxTitleLength = new TextInputBuilder()
 			.setCustomId("maxTitleLength")
-			.setLabel("Max title length (number between 1-100)")
+			.setLabel("Վերնագրի առավելագույն երկարություն (1-100 թիվ)")
 			.setRequired(true)
 			.setPlaceholder("50")
 			.setStyle(TextInputStyle.Short);
 		const regexJoinText = new TextInputBuilder()
 			.setCustomId("regexJoinText")
-			.setLabel("RegEx join (advanced)")
+			.setLabel("RegEx միացում (առաջադեմ)")
 			.setRequired(false)
-			.setPlaceholder("(empty string)")
+			.setPlaceholder("(դատարկ տող)")
 			.setStyle(TextInputStyle.Short);
 
 		return new ModalBuilder()
 			.setCustomId(this.customId)
-			.setTitle("Set a custom title format")
+			.setTitle("Սահմանել սեփական վերնագրի ձևաչափ")
 			.addComponents(makeRow(titleInput), makeRow(maxTitleLength), makeRow(regexJoinText));
 	}
 

--- a/src/modals/setting.ts
+++ b/src/modals/setting.ts
@@ -27,11 +27,11 @@ export default class SettingModal extends NeedleModal {
 	public get builder(): ModalBuilder {
 		const messageInput = new TextInputBuilder()
 			.setCustomId("setting")
-			.setLabel("value")
+			.setLabel("արժեք")
 			.setRequired(true)
 			.setStyle(TextInputStyle.Paragraph);
 		const row = new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(messageInput);
-		return new ModalBuilder().setCustomId(this.customId).setTitle("Change setting value").addComponents(row);
+		return new ModalBuilder().setCustomId(this.customId).setTitle("Փոխել կարգավորման արժեքը").addComponents(row);
 	}
 
 	public async submit(): Promise<void> {

--- a/src/modals/title.ts
+++ b/src/modals/title.ts
@@ -27,13 +27,13 @@ export default class TitleModal extends NeedleModal {
 	public get builder(): ModalBuilder {
 		const messageInput = new TextInputBuilder()
 			.setCustomId("title")
-			.setLabel("Title")
+			.setLabel("Վերնագիր")
 			.setRequired(true)
 			.setStyle(TextInputStyle.Short)
 			.setMinLength(1)
 			.setMaxLength(100);
 		const row = new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(messageInput);
-		return new ModalBuilder().setCustomId(this.customId).setTitle("Set thread title").addComponents(row);
+		return new ModalBuilder().setCustomId(this.customId).setTitle("Սահմանել թրեդի վերնագիրը").addComponents(row);
 	}
 
 	public async submit(): Promise<void> {

--- a/src/models/AutothreadChannelConfig.ts
+++ b/src/models/AutothreadChannelConfig.ts
@@ -54,7 +54,7 @@ export default class AutothreadChannelConfig {
 		closeButtonText: Nullish<string>,
 		closeButtonStyle: Nullish<string>,
 		titleButtonText: Nullish<string>,
-		titleButtonStyle: Nullish<string>
+		titleButtonStyle: Nullish<string>,
 	) {
 		this.channelId = channelId;
 		this.deleteBehavior = deleteBehavior ?? oldConfig?.deleteBehavior ?? DeleteBehavior.DeleteIfEmptyElseArchive;
@@ -63,9 +63,9 @@ export default class AutothreadChannelConfig {
 		this.slowmode = slowmode ?? oldConfig?.slowmode ?? 0;
 		this.statusReactions = statusReactions ?? oldConfig?.statusReactions ?? ToggleOption.Off;
 
-		this.closeButtonText = closeButtonText ?? oldConfig?.closeButtonText ?? "Archive thread";
+		this.closeButtonText = closeButtonText ?? oldConfig?.closeButtonText ?? "Արխիվացնել թրեդը";
 		this.closeButtonStyle = closeButtonStyle?.toLowerCase() ?? oldConfig?.closeButtonStyle ?? "green";
-		this.titleButtonText = titleButtonText ?? oldConfig?.titleButtonText ?? "Edit title";
+		this.titleButtonText = titleButtonText ?? oldConfig?.titleButtonText ?? "Խմբագրել վերնագիրը";
 		this.titleButtonStyle = titleButtonStyle?.toLowerCase() ?? oldConfig?.titleButtonStyle ?? "blurple";
 
 		this.replyType = replyType ?? oldConfig?.replyType ?? ReplyMessageOption.Default;
@@ -80,7 +80,7 @@ export default class AutothreadChannelConfig {
 	private getCustomReply(oldConfig: Nullish<AutothreadChannelConfig>, incomingCustomReply: Nullish<string>): string {
 		const switchingAwayFromCustom =
 			oldConfig?.replyType === ReplyMessageOption.Custom && this.replyType !== ReplyMessageOption.Custom;
-		return switchingAwayFromCustom ? "" : incomingCustomReply ?? oldConfig?.customReply ?? "";
+		return switchingAwayFromCustom ? "" : (incomingCustomReply ?? oldConfig?.customReply ?? "");
 	}
 
 	private getCustomTitle(oldConfig: Nullish<AutothreadChannelConfig>, incomingCustomTitle: Nullish<string>): string {

--- a/src/models/NeedleConfig.ts
+++ b/src/models/NeedleConfig.ts
@@ -26,15 +26,16 @@ export default interface NeedleConfig {
 export const defaultConfig: NeedleConfig = {
 	threadChannels: [],
 	settings: {
-		ErrorUnknown: "An unexpected error occurred. Please try again later.",
-		ErrorOnlyInThread: "You can only perform this action inside a thread.",
-		ErrorNoEffect: "This action will have no effect.",
-		ErrorInsufficientUserPerms: "You do not have permission to perform this action.",
-		ErrorInsufficientBotPerms: "The bot does not have permission to perform this action.",
-		ErrorMaxThreadRenames: "You can only rename a thread twice every 10 minutes. Please try again later.",
+		ErrorUnknown: "Տեղի ունեցավ անհայտ սխալ։ Խնդրում ենք փորձել ավելի ուշ։",
+		ErrorOnlyInThread: "Այս գործողությունը հնարավոր է միայն թրեդում։",
+		ErrorNoEffect: "Այս գործողությունը ազդեցություն չի ունենա։",
+		ErrorInsufficientUserPerms: "Դուք չունեք այս գործողությունը կատարելու թույլտվություն։",
+		ErrorInsufficientBotPerms: "Բոտը չունի այս գործողությունը կատարելու թույլտվություն։",
+		ErrorMaxThreadRenames: "Թրեդը կարելի է վերանվանել 10 րոպեում միայն երկու անգամ։ Խնդրում ենք փորձել ավելի ուշ։",
 
-		SuccessThreadCreated: "Thread automatically created by $USER_NICKNAME in $CHANNEL_MENTION",
-		SuccessThreadArchived: "Thread was archived by $USER_NICKNAME. Anyone can send a message to unarchive it.",
+		SuccessThreadCreated: "Թրեդը ավտոմատ ստեղծվել է $USER_NICKNAME-ի կողմից $CHANNEL_MENTION-ում",
+		SuccessThreadArchived:
+			"Թրեդը արխիվացվել է $USER_NICKNAME-ի կողմից։ Ցանկացածը կարող է հաղորդագրություն ուղարկել՝ այն ապարխիվացնելու համար։",
 
 		EmojiUnanswered: "🆕",
 		EmojiArchived: "✅",

--- a/src/models/enums/CommandCategory.ts
+++ b/src/models/enums/CommandCategory.ts
@@ -15,9 +15,9 @@ If not, see <https://www.gnu.org/licenses/>.
 
 // Note: The order of these enum values will be reflected in the /help command
 enum CommandCategory {
-	ThreadOnly = "Threads",
-	Info = "Information",
-	Configuration = "Configuration",
+	ThreadOnly = "Թրեդեր",
+	Info = "Տեղեկություն",
+	Configuration = "Կարգավորում",
 }
 
 export default CommandCategory;

--- a/src/services/CommandExecutorService.ts
+++ b/src/services/CommandExecutorService.ts
@@ -33,7 +33,7 @@ export default class CommandExecutorService {
 
 		const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
 			this.getBugReportButton(),
-			this.getSupportServerButton()
+			this.getSupportServerButton(),
 		);
 
 		await context.interaction.reply({
@@ -46,7 +46,7 @@ export default class CommandExecutorService {
 	private getSupportServerButton(): ButtonBuilder {
 		return new ButtonBuilder()
 			.setEmoji("🙋")
-			.setLabel("Support server")
+			.setLabel("Աջակցության սերվեր")
 			.setURL("https://discord.gg/8BmnndXHp6")
 			.setStyle(ButtonStyle.Link);
 	}
@@ -54,7 +54,7 @@ export default class CommandExecutorService {
 	private getBugReportButton(): ButtonBuilder {
 		return new ButtonBuilder()
 			.setEmoji("🐛")
-			.setLabel("Report a bug")
+			.setLabel("Տեղեկացնել սխալի մասին")
 			.setURL("https://needle.gg/suggest")
 			.setStyle(ButtonStyle.Link);
 	}

--- a/src/services/InformationService.ts
+++ b/src/services/InformationService.ts
@@ -56,13 +56,13 @@ export default class InformationService {
 			}
 		}
 
-		return largestServer ? `${largestServer.name} (${formatNumber(largestServer.memberCount)} members)` : "None";
+		return largestServer ? `${largestServer.name} (${formatNumber(largestServer.memberCount)} մասնակիցներ)` : "Չկա";
 	}
 
 	// Generate a string like 1d 8h 23m 12s or 8h 23m 0s
 	public getUptimeString(): string {
 		const uptimeMs = this.bot.client.uptime;
-		if (!uptimeMs) return "Not online";
+		if (!uptimeMs) return "Չի միացված";
 
 		const days = Math.floor(uptimeMs / 1000 / 60 / 60 / 24);
 		const hours = Math.floor((uptimeMs / 1000 / 60 / 60) % 24);

--- a/src/services/ThreadCreationService.ts
+++ b/src/services/ThreadCreationService.ts
@@ -27,7 +27,7 @@ import {
 } from "discord.js";
 import { getRequiredPermissions, tryReact } from "../helpers/djsHelpers.js";
 import { wait } from "../helpers/promiseHelpers.js";
-import { clampWithElipse, extractRegex, plural } from "../helpers/stringHelpers.js";
+import { clampWithElipse, extractRegex } from "../helpers/stringHelpers.js";
 import type AutothreadChannelConfig from "../models/AutothreadChannelConfig.js";
 import ReplyMessageOption from "../models/enums/ReplyMessageOption.js";
 import ToggleOption from "../models/enums/ToggleOption.js";
@@ -93,7 +93,7 @@ export default class ThreadCreationService {
 		const requiredPermissions = getRequiredPermissions(channelConfig.slowmode, rawReplyMessageContent);
 		if (!botPermissions.has(requiredPermissions)) {
 			const missing = botPermissions.missing(requiredPermissions);
-			const errorMessage = `Missing ${plural("permission", missing.length)}:`;
+			const errorMessage = `Պակասում է ${missing.length > 1 ? "թույլտվություններ" : "թույլտվություն"}:`;
 			await message.channel.send(`${errorMessage}\n    - ${missing.join("\n    - ")}`);
 			return;
 		}
@@ -165,7 +165,7 @@ export default class ThreadCreationService {
 
 		const title = await variables.replace(rawTitle);
 		const output = clampWithElipse(title, config.titleMaxLength);
-		return output.trim().length > 0 ? output : "New Thread";
+		return output.trim().length > 0 ? output : "Նոր թրեդ";
 	}
 
 	private getMessageContent(message: Message, variables: MessageVariables) {
@@ -223,7 +223,7 @@ export default class ThreadCreationService {
 			case "red":
 				return ButtonStyle.Danger;
 			default:
-				throw new Error("Invalid button color: " + setting.toLowerCase());
+				throw new Error("Սխալ կոճակի գույն: " + setting.toLowerCase());
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- translate default config messages and categories to Armenian
- localize command, modal, and service replies

## Testing
- `npm run lint` *(fails: code style issues in unmodified files)*


------
https://chatgpt.com/codex/tasks/task_b_6892ec60b5388330bc0c40ede0b4163c